### PR TITLE
Feat: Adding JSON support

### DIFF
--- a/blake2b/hash.go
+++ b/blake2b/hash.go
@@ -32,6 +32,10 @@ func (h *BLAKE2b) HashLength() int {
 	return _hashlength
 }
 
+func (h *BLAKE2b) HashName() string {
+	return "blake2b"
+}
+
 // Hash generates a BLAKE2b hash from input byte arrays.
 func (h *BLAKE2b) Hash(data ...[]byte) []byte {
 	var hash [_hashlength]byte

--- a/dot.go
+++ b/dot.go
@@ -63,7 +63,7 @@ func (t *MerkleTree) DOTProof(proof *Proof, lf Formatter, bf Formatter) string {
 	rootIndices := make(map[uint64]int)
 
 	if proof != nil {
-		index := proof.Index + uint64(math.Ceil(float64(len(t.nodes))/2))
+		index := proof.Index + uint64(math.Ceil(float64(len(t.Nodes))/2))
 		valueIndices[proof.Index] = 1
 
 		for range proof.Hashes {
@@ -71,7 +71,7 @@ func (t *MerkleTree) DOTProof(proof *Proof, lf Formatter, bf Formatter) string {
 			index /= 2
 		}
 
-		numRootNodes := uint64(math.Exp2(math.Ceil(math.Log2(float64(len(t.data))))-float64(len(proof.Hashes))+1)) - 1
+		numRootNodes := uint64(math.Exp2(math.Ceil(math.Log2(float64(len(t.Data))))-float64(len(proof.Hashes))+1)) - 1
 		for i := uint64(1); i <= numRootNodes; i++ {
 			rootIndices[i] = 1
 		}
@@ -114,31 +114,31 @@ func (t *MerkleTree) dot(rootIndices, valueIndices, proofIndices map[uint64]int,
 	builder.WriteString("digraph MerkleTree {")
 	builder.WriteString("rankdir = TB;")
 	builder.WriteString("node [shape=rectangle margin=\"0.2,0.2\"];")
-	empty := make([]byte, len(t.nodes[1]))
-	dataLen := len(t.data)
-	valuesOffset := int(math.Ceil(float64(len(t.nodes)) / 2))
+	empty := make([]byte, len(t.Nodes[1]))
+	dataLen := len(t.Data)
+	valuesOffset := int(math.Ceil(float64(len(t.Nodes)) / 2))
 	var nodeBuilder strings.Builder
 	nodeBuilder.WriteString("{rank=same")
 	indexSalt := make([]byte, 4)
 	for i := 0; i < valuesOffset; i++ {
 		if i < dataLen {
 			// Value
-			builder.WriteString(fmt.Sprintf("\"%s\" [shape=oval", lf.Format(t.data[i])))
+			builder.WriteString(fmt.Sprintf("\"%s\" [shape=oval", lf.Format(t.Data[i])))
 			if valueIndices[uint64(i)] > 0 {
 				builder.WriteString(" style=filled fillcolor=\"#ff4040\"")
 			}
 			builder.WriteString("];")
 
 			// Hash of the value
-			if t.salt {
+			if t.Salt {
 				binary.BigEndian.PutUint32(indexSalt, uint32(i))
-				builder.WriteString(fmt.Sprintf("\"%s\"->%d [label=\"+%0x\"];", lf.Format(t.data[i]), valuesOffset+i, indexSalt))
+				builder.WriteString(fmt.Sprintf("\"%s\"->%d [label=\"+%0x\"];", lf.Format(t.Data[i]), valuesOffset+i, indexSalt))
 			} else {
-				builder.WriteString(fmt.Sprintf("\"%s\"->%d;", lf.Format(t.data[i]), valuesOffset+i))
+				builder.WriteString(fmt.Sprintf("\"%s\"->%d;", lf.Format(t.Data[i]), valuesOffset+i))
 			}
 
 			nodeBuilder.WriteString(fmt.Sprintf(";%d", valuesOffset+i))
-			builder.WriteString(fmt.Sprintf("%d [label=\"%s\"", valuesOffset+i, bf.Format(t.nodes[valuesOffset+i])))
+			builder.WriteString(fmt.Sprintf("%d [label=\"%s\"", valuesOffset+i, bf.Format(t.Nodes[valuesOffset+i])))
 			if proofIndices[uint64(i+valuesOffset)] > 0 {
 				builder.WriteString(" style=filled fillcolor=\"#00ff00\"")
 			} else if rootIndices[uint64(i+valuesOffset)] > 0 {
@@ -169,7 +169,7 @@ func (t *MerkleTree) dot(rootIndices, valueIndices, proofIndices map[uint64]int,
 
 	// Add branches
 	for i := valuesOffset - 1; i > 0; i-- {
-		builder.WriteString(fmt.Sprintf("%d [label=\"%s\"", i, bf.Format(t.nodes[i])))
+		builder.WriteString(fmt.Sprintf("%d [label=\"%s\"", i, bf.Format(t.Nodes[i])))
 		if rootIndices[uint64(i)] > 0 {
 			builder.WriteString(" style=filled fillcolor=\"#8080ff\"")
 		} else if proofIndices[uint64(i)] > 0 {

--- a/encoding.go
+++ b/encoding.go
@@ -3,13 +3,13 @@ package merkletree
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/wealdtech/go-merkletree/blake2b"
 	"github.com/wealdtech/go-merkletree/keccak256"
 	"github.com/wealdtech/go-merkletree/sha3"
 )
 
 func (t *MerkleTree) MarshalJSON() ([]byte, error) {
-
 	type ExportTree MerkleTree
 
 	return json.Marshal(&struct {
@@ -22,7 +22,6 @@ func (t *MerkleTree) MarshalJSON() ([]byte, error) {
 }
 
 func (t *MerkleTree) UnmarshalJSON(data []byte) error {
-
 	type ExportTree MerkleTree
 	aux := &struct {
 		HashType string `json:"hash_type"`

--- a/encoding.go
+++ b/encoding.go
@@ -1,0 +1,51 @@
+package merkletree
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/wealdtech/go-merkletree/blake2b"
+	"github.com/wealdtech/go-merkletree/keccak256"
+	"github.com/wealdtech/go-merkletree/sha3"
+)
+
+func (t *MerkleTree) MarshalJSON() ([]byte, error) {
+
+	type ExportTree MerkleTree
+
+	return json.Marshal(&struct {
+		HashType string `json:"hash_type"`
+		*ExportTree
+	}{
+		HashType:   t.Hash.HashName(),
+		ExportTree: (*ExportTree)(t),
+	})
+}
+
+func (t *MerkleTree) UnmarshalJSON(data []byte) error {
+
+	type ExportTree MerkleTree
+	aux := &struct {
+		HashType string `json:"hash_type"`
+		*ExportTree
+	}{
+		ExportTree: (*ExportTree)(t),
+	}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	switch aux.HashType {
+	case "sha512":
+		aux.Hash = sha3.New512()
+	case "sha256":
+		aux.Hash = sha3.New256()
+	case "blake2b":
+		aux.Hash = blake2b.New()
+	case "keccak256":
+		aux.Hash = keccak256.New()
+	default:
+		return fmt.Errorf("cannot parse hash type")
+	}
+
+	return nil
+}

--- a/encoding.go
+++ b/encoding.go
@@ -2,8 +2,8 @@ package merkletree
 
 import (
 	"encoding/json"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/wealdtech/go-merkletree/blake2b"
 	"github.com/wealdtech/go-merkletree/keccak256"
 	"github.com/wealdtech/go-merkletree/sha3"
@@ -43,7 +43,7 @@ func (t *MerkleTree) UnmarshalJSON(data []byte) error {
 	case "keccak256":
 		aux.Hash = keccak256.New()
 	default:
-		return fmt.Errorf("cannot parse hash type")
+		return errors.New("cannot parse hash type")
 	}
 
 	return nil

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -2,9 +2,10 @@ package merkletree
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"github.com/wealdtech/go-merkletree/sha3"
-	"testing"
 )
 
 func TestEncoding(t *testing.T) {
@@ -29,5 +30,4 @@ func TestEncoding(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, tree.Root(), newTree.Root())
-
 }

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -1,0 +1,33 @@
+package merkletree
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"github.com/wealdtech/go-merkletree/sha3"
+	"testing"
+)
+
+func TestEncoding(t *testing.T) {
+	hashType := sha3.New512()
+
+	data := [][]byte{
+		[]byte("Foo"),
+		[]byte("Bar"),
+	}
+
+	tree, err := NewTree(
+		WithData(data),
+		WithHashType(hashType),
+	)
+	require.NoError(t, err)
+
+	exported, err := json.Marshal(tree)
+	require.NoError(t, err)
+
+	var newTree MerkleTree
+	err = json.Unmarshal(exported, &newTree)
+	require.NoError(t, err)
+
+	require.Equal(t, tree.Root(), newTree.Root())
+
+}

--- a/hash.go
+++ b/hash.go
@@ -21,6 +21,9 @@ type HashType interface {
 	// Hash calculates the hash of a given input.
 	Hash(...[]byte) []byte
 
+	// HashName returns the name of the hashing algorithm to be used in encoding
+	HashName() string
+
 	// HashLength provides the length of the hash.
 	HashLength() int
 }

--- a/keccak256/hash.go
+++ b/keccak256/hash.go
@@ -32,6 +32,10 @@ func (h *Keccak256) HashLength() int {
 	return _hashlength
 }
 
+func (h *Keccak256) HashName() string {
+	return "keccak256"
+}
+
 // Hash generates a Keccak-256 hash from a byte array.
 func (h *Keccak256) Hash(data ...[]byte) []byte {
 	hash := sha3.NewLegacyKeccak256()

--- a/proof_test.go
+++ b/proof_test.go
@@ -49,7 +49,7 @@ func TestSaltedProof(t *testing.T) {
 				WithSalt(test.salt),
 			)
 			assert.Nil(t, err, fmt.Sprintf("failed to create tree at test %d", i))
-			assert.Equal(t, test.salt, tree.Salt(), fmt.Sprintf("unexpected salt at test %d", i))
+			assert.Equal(t, test.salt, tree.GetSalt(), fmt.Sprintf("unexpected salt at test %d", i))
 			assert.Equal(t, test.saltedRoot, tree.Root(), fmt.Sprintf("unexpected root at test %d", i))
 			for j, data := range test.data {
 				proof, err := tree.GenerateProof(data, 0)

--- a/sha3/sha256.go
+++ b/sha3/sha256.go
@@ -32,6 +32,10 @@ func (h *SHA256) HashLength() int {
 	return _256hashlength
 }
 
+func (h *SHA256) HashName() string {
+	return "sha256"
+}
+
 // Hash generates a SHA3 hash from input byte arrays.
 func (h *SHA256) Hash(data ...[]byte) []byte {
 	var hash [_256hashlength]byte

--- a/sha3/sha512.go
+++ b/sha3/sha512.go
@@ -32,6 +32,10 @@ func (h *SHA512) HashLength() int {
 	return _512hashlength
 }
 
+func (h *SHA512) HashName() string {
+	return "sha512"
+}
+
 // Hash generates a SHA3 hash from input byte arrays.
 func (h *SHA512) Hash(data ...[]byte) []byte {
 	var hash [_512hashlength]byte


### PR DESCRIPTION
After opening https://github.com/wealdtech/go-merkletree/pull/5 I realized I was doing something totally dumb instead of the preferred way to handle custom marshalling. 

This PR adds support for marshalling and unmarshalling `MerkleTree` objects using JSON.